### PR TITLE
fix: url in post overflows if they are too long, and layout would be …

### DIFF
--- a/source/css/matery.css
+++ b/source/css/matery.css
@@ -919,6 +919,7 @@ article .article-tags .chip {
     color: #42b983;
     font-weight: 500;
     text-decoration: underline;
+    word-wrap:break-word;
 }
 
 #articleContent img {


### PR DESCRIPTION
…influenced on mobile

![image](https://user-images.githubusercontent.com/8568937/51740202-54d35a80-20ce-11e9-98d6-25f6c838293b.png)

like this