### PR TITLE
优化

### DIFF
--- a/layout/_partial/prev-next.ejs
+++ b/layout/_partial/prev-next.ejs
@@ -82,7 +82,7 @@ var featureImages = theme.featureImages;
         <% } else { %>
         <div class="article col s12 m6" data-aos="fade-up" data-aos="fade-up">
             <div class="article-badge left-badge text-color">
-                <i class="fas fa-chevron-left"></i>&nbsp;<%= __('curr') %>
+                <i class="far fa-dot-circle"></i>&nbsp;<%= __('curr') %>
             </div>
             <div class="card">
                 <a href="<%- url_for(page.path) %>">
@@ -208,7 +208,7 @@ var featureImages = theme.featureImages;
         <% } else { %>
         <div class="article col s12 m6" data-aos="fade-up">
             <div class="article-badge right-badge text-color">
-                <%= __('curr') %>&nbsp;<i class="fas fa-chevron-right"></i>
+                <%= __('curr') %>&nbsp;<i class="far fa-dot-circle"></i>
             </div>
             <div class="card">
                 <a href="<%- url_for(page.path) %>">


### PR DESCRIPTION
1. 优化文章推荐中”本篇“的指示图标，由左右改为中心圆点。由于是本篇，所以箭头不太符合常规。

![image](https://user-images.githubusercontent.com/33802186/66329489-2eee9d00-e961-11e9-826d-521b0d549c0e.png)
![image](https://user-images.githubusercontent.com/33802186/66329499-33b35100-e961-11e9-91cd-ad5b08541069.png)
