### PR TITLE
优化代码框缩小后的效果

### DIFF
--- a/source/libs/codeBlock/codeCopy.js
+++ b/source/libs/codeBlock/codeCopy.js
@@ -1,8 +1,6 @@
+// 代码框复制
+
 $(function () {
-    /**
-     * 代码复制按钮
-     * Add copy icon
-     */
     $('.line-numbers').wrap('<div class="code-area" style="position: relative"></div>')
     var $copyIcon = $('<i class="fas fa-copy code_copy" title="复制代码" aria-hidden="true"></i>')
     $('.code-area').prepend($copyIcon)

--- a/source/libs/codeBlock/codeLang.js
+++ b/source/libs/codeBlock/codeLang.js
@@ -3,7 +3,7 @@
 $(function () {
   var $highlight_lang = $('<div class="code_lang" title="代码语言"></div>')
 
-  $('pre').before($highlight_lang)
+  $('pre').after($highlight_lang)
   $('pre').each(function () {
     var lang_name = $('pre code').attr('class').split('-')[1];
 

--- a/source/libs/codeBlock/codeLang.js
+++ b/source/libs/codeBlock/codeLang.js
@@ -3,7 +3,7 @@ $(function () {
    * 代码框语言识别
    */
   var $highlight_lang = $('<div class="code_lang" title="代码语言"></div>')
-  $('pre').after($highlight_lang)
+  $('pre').before($highlight_lang)
   $('pre').each(function () {
     var lang_name = $('pre code').attr('class').split('-')[1];
 

--- a/source/libs/codeBlock/codeLang.js
+++ b/source/libs/codeBlock/codeLang.js
@@ -1,15 +1,14 @@
+// 代码框语言识别
+
 $(function () {
-  /**
-   * 代码框语言识别
-   */
   var $highlight_lang = $('<div class="code_lang" title="代码语言"></div>')
+
   $('pre').before($highlight_lang)
   $('pre').each(function () {
     var lang_name = $('pre code').attr('class').split('-')[1];
 
     // 首字母大写
     lang_name = lang_name.slice(0, 1).toUpperCase() + lang_name.slice(1);
-
     $('pre').siblings(".code_lang").text(lang_name)
   })
 });

--- a/source/libs/codeBlock/codeShrink.js
+++ b/source/libs/codeBlock/codeShrink.js
@@ -1,8 +1,6 @@
-$(function () {
-  /**
-   * 代碼收縮
-   */
+// 代码框收缩
 
+$(function () {
   var $code_expand = $('<i class="fas fa-angle-up code-expand" aria-hidden="true"></i>')
 
   $('.code-area').prepend($code_expand)
@@ -10,9 +8,11 @@ $(function () {
     if ($(this).hasClass('code-closed')) {
       $(this).siblings('pre').find('code').show();
       $(this).removeClass('code-closed');
+      $(this).siblings('pre').append('<style> pre::before { height: 16px; } </style>');
     } else {
       $(this).siblings('pre').find('code').hide();
       $(this).addClass('code-closed');
+      $(this).siblings('pre').append('<style> pre::before { height: 0px; } </style>');
     }
   })
 });


### PR DESCRIPTION
优化代码框缩小后的效果，使其缩小后高度更小
原来：
![image](https://user-images.githubusercontent.com/33802186/66731146-6a6cf800-ee88-11e9-8843-0ce7f025f6a3.png)
现在：
![image](https://user-images.githubusercontent.com/33802186/66731150-70fb6f80-ee88-11e9-8225-c7bcdb702bc6.png)
