### PR TITLE
优化代码块功能

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -142,9 +142,10 @@ toc:
 
 # 代码块相关
 code:
-  break: false # 代码是否折行
+  lang: true # 代码块是否显示名称
   copy: true # 代码块是否可复制
   shrink: true # 代码块是否可以收缩
+  break: false # 代码是否折行
 
 # 是否激活文章末尾的打赏功能，默认激活（你替换为的你自己的微信、支付宝二维码图片、或者使用网络图片也可以）.
 reward:

--- a/layout/_partial/post-detail.ejs
+++ b/layout/_partial/post-detail.ejs
@@ -141,11 +141,20 @@
 </script>
 <% } %>
 
-<!-- 代码块复制功能 -->
-<% if (theme.code.copy) { %>
-<script type="text/javascript" src="<%- theme.libs.js.clipboard %>"></script>
-<script type="text/javascript" src="/libs/codeBlock/codeCopy.js"></script>
+<!-- 代码块功能依赖 -->
+<% if (theme.code.lang || theme.code.copy || theme.code.shrink) { %>
+<script type="text/javascript" src="/libs/codeBlock/codeBlockFuction.js"></script>
+<% } %>
+
+<!-- 代码语言 -->
+<% if (theme.code.lang) { %>
 <script type="text/javascript" src="/libs/codeBlock/codeLang.js"></script>
+<% } %>
+    
+<!-- 代码块复制 -->
+<% if (theme.code.copy) { %>
+<script type="text/javascript" src="/libs/codeBlock/codeCopy.js"></script>
+<script type="text/javascript" src="<%- theme.libs.js.clipboard %>"></script>
 <% } %>
 
 <!-- 代码块收缩 -->
@@ -154,10 +163,8 @@
 <% } %>
 
 <!-- 代码块折行 -->
-<style type="text/css">
 <% if (!theme.code.break) { %>
-code[class*="language-"], pre[class*="language-"] {
-    white-space: pre !important;
-}
-<% } %>
+<style type="text/css">
+code[class*="language-"], pre[class*="language-"] { white-space: pre !important; }
 </style>
+<% } %>

--- a/source/css/matery.css
+++ b/source/css/matery.css
@@ -168,9 +168,13 @@ code {
     transform: rotate(0deg);
 }
 
-.code-closed {
+.code-closed .code-expand {
     transform: rotate(-180deg) !important;
     transition: all .3s;
+}
+
+.code-closed pre::before {
+    height: 0px;
 }
 
 pre code {

--- a/source/css/matery.css
+++ b/source/css/matery.css
@@ -98,6 +98,19 @@ blockquote {
     background-color: rgba(66, 185, 131, .1);
 }
 
+.line-numbers-rows {
+    border-right-width: 0px !important;
+}
+
+.line-numbers {
+    padding: 1.5rem 1.5rem 1.5rem 3.3rem !important;
+    margin: 1rem 0 !important;
+    background: #272822;
+    overflow: auto;
+    border-radius: 0.35rem;
+    tab-size: 4;
+}
+
 pre {
     padding: 1.5rem 1.5rem 1.5rem 3.3rem !important;
     margin: 1rem 0 !important;

--- a/source/libs/codeBlock/codeBlockFuction.js
+++ b/source/libs/codeBlock/codeBlockFuction.js
@@ -1,0 +1,5 @@
+// 代码块功能依赖
+
+$(function () {
+    $('pre').wrap('<div class="code-area" style="position: relative"></div>');
+});

--- a/source/libs/codeBlock/codeCopy.js
+++ b/source/libs/codeBlock/codeCopy.js
@@ -1,12 +1,12 @@
-// 代码框复制
+// 代码块一键复制
 
 $(function () {
-    $('.line-numbers').wrap('<div class="code-area" style="position: relative"></div>')
-    var $copyIcon = $('<i class="fas fa-copy code_copy" title="复制代码" aria-hidden="true"></i>')
-    $('.code-area').prepend($copyIcon)
+    var $copyIcon = $('<i class="fas fa-copy code_copy" title="复制代码" aria-hidden="true"></i>');
+    
+    $('.code-area').prepend($copyIcon);
     new ClipboardJS('.fa-copy', {
         target: function (trigger) {
             return trigger.nextElementSibling;
         }
-    })
+    });
 });

--- a/source/libs/codeBlock/codeLang.js
+++ b/source/libs/codeBlock/codeLang.js
@@ -1,7 +1,7 @@
 // 代码块语言识别
 
 $(function () {
-  var $highlight_lang = $('<div class="code_lang" title="代码语言"></div>');
+  var $highlight_lang = $('<div class="code_lang" title="代码语言" aria-hidden="true"></div>');
   
   $('pre').after($highlight_lang);
   $('pre').each(function () {

--- a/source/libs/codeBlock/codeLang.js
+++ b/source/libs/codeBlock/codeLang.js
@@ -1,14 +1,14 @@
-// 代码框语言识别
+// 代码块语言识别
 
 $(function () {
-  var $highlight_lang = $('<div class="code_lang" title="代码语言"></div>')
-
-  $('pre').after($highlight_lang)
+  var $highlight_lang = $('<div class="code_lang" title="代码语言"></div>');
+  
+  $('pre').after($highlight_lang);
   $('pre').each(function () {
     var lang_name = $('pre code').attr('class').split('-')[1];
 
     // 首字母大写
     lang_name = lang_name.slice(0, 1).toUpperCase() + lang_name.slice(1);
-    $('pre').siblings(".code_lang").text(lang_name)
-  })
+    $('pre').siblings(".code_lang").text(lang_name);
+  });
 });

--- a/source/libs/codeBlock/codeShrink.js
+++ b/source/libs/codeBlock/codeShrink.js
@@ -5,14 +5,12 @@ $(function () {
 
   $('.code-area').prepend($code_expand)
   $('.code-expand').on('click', function () {
-    if ($(this).hasClass('code-closed')) {
+    if ($(this).parent().hasClass('code-closed')) {
       $(this).siblings('pre').find('code').show();
-      $(this).removeClass('code-closed');
-      $(this).siblings('pre').append('<style> pre::before { height: 16px; } </style>');
+      $(this).parent().removeClass('code-closed');
     } else {
       $(this).siblings('pre').find('code').hide();
-      $(this).addClass('code-closed');
-      $(this).siblings('pre').append('<style> pre::before { height: 0px; } </style>');
+      $(this).parent().addClass('code-closed');
     }
   })
 });

--- a/source/libs/codeBlock/codeShrink.js
+++ b/source/libs/codeBlock/codeShrink.js
@@ -1,9 +1,9 @@
-// 代码框收缩
+// 代码块收缩
 
 $(function () {
-  var $code_expand = $('<i class="fas fa-angle-up code-expand" aria-hidden="true"></i>')
+  var $code_expand = $('<i class="fas fa-angle-up code-expand" aria-hidden="true"></i>');
 
-  $('.code-area').prepend($code_expand)
+  $('.code-area').prepend($code_expand);
   $('.code-expand').on('click', function () {
     if ($(this).parent().hasClass('code-closed')) {
       $(this).siblings('pre').find('code').show();
@@ -12,5 +12,5 @@ $(function () {
       $(this).siblings('pre').find('code').hide();
       $(this).parent().addClass('code-closed');
     }
-  })
+  });
 });


### PR DESCRIPTION
1. 代码块功能区域现在可以单独控制是否开启
![508E735ED6033C9DAF781069C69BBE9F](https://user-images.githubusercontent.com/33802186/66744199-681d9480-eeae-11e9-9d0c-02148f7c7996.png)
2. 去除行号之后的竖线，使代码块更加美观
3. 优化代码块的缩进方式，显示行号与关闭行号现在是不同的缩进距离
![image](https://user-images.githubusercontent.com/33802186/66744245-86839000-eeae-11e9-8358-a3604027e32a.png)
![image](https://user-images.githubusercontent.com/33802186/66744252-8c797100-eeae-11e9-8d34-a20b5b018abf.png)

4. 减少代码块与其他区域的依赖性，开启关闭行号均可正常显示
5. 优化代码
6. **目前存在问题所有代码块语言均显示为第一个代码块的语言，建议目前先不开启**