### PR TITLE
修复没有行号时无法获取代码语言的问题

### DIFF
--- a/source/libs/codeBlock/codeLang.js
+++ b/source/libs/codeBlock/codeLang.js
@@ -7,12 +7,11 @@ $(function () {
   $('pre').each(function () {
     var code_language = $(this).attr('class');
 
-    if (!code_language || code_language.indexOf("-") === -1) {
+    if (!code_language) {
       return true;
-    };
+    }
+    var lang_name = code_language.replace("line-numbers", "").trim().replace("language-", "").trim();
 
-    var lang_name = code_language.split('-')[2];
-    
     // 首字母大写
     lang_name = lang_name.slice(0, 1).toUpperCase() + lang_name.slice(1);
     $(this).siblings(".code_lang").text(lang_name);

--- a/source/libs/codeBlock/codeLang.js
+++ b/source/libs/codeBlock/codeLang.js
@@ -9,7 +9,7 @@ $(function () {
 
     if (!code_language) {
       return true;
-    }
+    };
     var lang_name = code_language.replace("line-numbers", "").trim().replace("language-", "").trim();
 
     // 首字母大写


### PR DESCRIPTION
修复没有行号时无法获取代码语言的问题，感谢@liuzhihangs
![image](https://user-images.githubusercontent.com/33802186/66821854-bd70a900-ef75-11e9-8179-2f4f606eb5e6.png)
