### PR TITLE
优化代码块布局

### DIFF
--- a/source/css/matery.css
+++ b/source/css/matery.css
@@ -136,7 +136,7 @@ pre {
 
 code {
     padding: 1px 5px;
-    top: 10px !important;
+    top: 13px !important;
     font-family: Inconsolata, Monaco, Consolas, 'Courier New', Courier, monospace;
     font-size: 0.91rem;
     color: #e96900;

--- a/source/css/matery.css
+++ b/source/css/matery.css
@@ -120,14 +120,7 @@ pre {
     tab-size: 4;
 }
 
-pre::before {
-    content: "";
-    height: 16px;
-    margin-bottom: 0;
-    display: block;
-}
-
-pre::after {
+.code-area::after {
     content: " ";
     position: absolute;
     border-radius: 50%;
@@ -143,6 +136,7 @@ pre::after {
 
 code {
     padding: 1px 5px;
+    top: 10px !important;
     font-family: Inconsolata, Monaco, Consolas, 'Courier New', Courier, monospace;
     font-size: 0.91rem;
     color: #e96900;


### PR DESCRIPTION
1. 代码块左上角三个点现在固定位置
2. 代码块右侧现在会有多的空间，不会紧贴边框

之前：
![image](https://user-images.githubusercontent.com/33802186/67065532-3dc72200-f1a1-11e9-8663-3e7525b2aa97.png)
现在：
![image](https://user-images.githubusercontent.com/33802186/67065542-4586c680-f1a1-11e9-81d0-cb39df6df6b0.png)
