### PR TITLE
首页轮播图和推荐文章自定义功能

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -58,6 +58,9 @@ cover:
   autoLoop: true # 是否自动轮播. Whether it is automatically rotated.
   duration: 120 # 切换延迟时间. Switching delay time.
   intervalTime: 5000 # 自动切换下一张的间隔时间. Automatically switch the interval of the next one.
+  useConfig: false # 是否使用配置文件, 在 _data/covers.json 下配置推荐文章, false则使用主题在文章中的配置 cover coverImg
+  # useConfig 使用方式: 将主题 hexo-theme-matery/source/_data/covers.json 移动到 my-blog/source/_data/下修改配置即可
+
 
 # index page dream text,
 # 配置首页显示"梦想"的语句.
@@ -103,6 +106,8 @@ video:
 # 是否显示推荐文章的标题
 recommend:
   showTitle: true
+  useConfig: false # 是否使用配置文件, 在 _data/recommends.json 下配置推荐文章, false则会走主题配置的 top 属性
+  # useConfig 使用方式: 将主题 hexo-theme-matery/source/_data/recommends.json 移动到 my-blog/source/_data/下修改配置即可
 
 # Configure website favicon and LOGO
 # 配置网站favicon和网站LOGO

--- a/layout/_partial/index-cover.ejs
+++ b/layout/_partial/index-cover.ejs
@@ -52,11 +52,15 @@
 <%
 // get all cover posts.
 var coverPosts = [];
-site.posts.forEach(function (post) {
-    if (post.cover) {
-        coverPosts.push(post);
-    }
-});
+if (theme.cover.useConfig) {
+    coverPosts = site.data.covers;
+} else {
+    site.posts.forEach(function (post) {
+        if (post.cover) {
+            coverPosts.push(post);
+        }
+    });
+}
 var coverPostsCount = coverPosts.length;
 %>
 

--- a/layout/_widget/recommend.ejs
+++ b/layout/_widget/recommend.ejs
@@ -1,11 +1,15 @@
 <%
     // get all top posts.
     var topPosts = [];
-    site.posts.forEach(function (post) {
-        if (post.top) {
-            topPosts.push(post);
-        }
-    });
+    if (theme.recommend.useConfig) {
+        topPosts = site.data.recommends;
+    } else {
+        site.posts.forEach(function (post) {
+            if (post.top) {
+                topPosts.push(post);
+            }
+        });
+    }
     var topPostsCount = topPosts.length;
 %>
 
@@ -52,9 +56,13 @@
         <div class="post-card" style="background-image: url('<%- featureImg %>')">
             <div class="post-body">
                 <div class="post-categories">
-                    <% post.categories.forEach(category => { %>
-                    <a href="<%- url_for(category.path) %>" class="category"><%- category.name %></a>
-                    <% }); %>
+                    <% if (theme.recommend.useConfig) { %>
+                        <a href="<%- post.categoryPath %>" class="category"><%- post.categoryName %></a>
+                    <% } else { %>
+                        <% post.categories.forEach(category => { %>
+                            <a href="<%- url_for(category.path) %>" class="category"><%- category.name %></a>
+                        <% }); %>
+                    <% } %>
                 </div>
                 <a href="<%- url_for(post.path) %>">
                     <h3 class="post-title"><%- post.title %></h3>
@@ -90,9 +98,13 @@
         <div class="post-card" style="background-image: url('<%- featureImg %>')">
             <div class="post-body">
                 <div class="post-categories">
-                    <% post.categories.forEach(category => { %>
-                    <a href="<%- url_for(category.path) %>" class="category"><%- category.name %></a>
-                    <% }); %>
+                    <% if (theme.recommend.useConfig) { %>
+                        <a href="<%- post.categoryPath %>" class="category"><%- post.categoryName %></a>
+                    <% } else { %>
+                        <% post.categories.forEach(category => { %>
+                            <a href="<%- url_for(category.path) %>" class="category"><%- category.name %></a>
+                        <% }); %>
+                    <% } %>
                 </div>
                 <a href="<%- url_for(post.path) %>">
                     <h3 class="post-title"><%- post.title %></h3>

--- a/source/_data/covers.json
+++ b/source/_data/covers.json
@@ -1,0 +1,20 @@
+[
+  {
+    "title": "轮播文章1",
+    "path": "https://github.com/blinkfox/hexo-theme-matery/blob/develop/README_CN.md",
+    "coverImg": "https://res.cloudinary.com/liuzhihang/image/upload/v1568885685/feature/2019-09-07-nt6X1A_krvmnd.jpg",
+    "summary": "path可以使用绝对路径也可以使用相对路径"
+  },
+  {
+    "title": "轮播文章2",
+    "path": "https://liuzhihang.com",
+    "coverImg": "https://res.cloudinary.com/liuzhihang/image/upload/v1568873774/feature/cyber-security.jpg",
+    "summary": "A thousand journey is started by taking the first step."
+  },
+  {
+    "title": "轮播文章3",
+    "path": "/index.html",
+    "coverImg": "https://liuzhihang.com/oss/image/2019-09-11-wallhaven-nk7ypq.jpg",
+    "summary": "这里是轮播文章3的介绍"
+  }
+]

--- a/source/_data/friends.json
+++ b/source/_data/friends.json
@@ -1,0 +1,23 @@
+[
+  {
+    "avatar": "http://image.luokangyuan.com/1_qq_27922023.jpg",
+    "name": "码酱",
+    "introduction": "我不是大佬，只是在追寻大佬的脚步",
+    "url": "http://luokangyuan.com/",
+    "title": "前去学习"
+  },
+  {
+    "avatar": "http://image.luokangyuan.com/4027734.jpeg",
+    "name": "闪烁之狐",
+    "introduction": "编程界大佬，技术牛，人还特别好，不懂的都可以请教大佬",
+    "url": "https://blinkfox.github.io/",
+    "title": "前去学习"
+  },
+  {
+    "avatar": "http://image.luokangyuan.com/avatar.jpg",
+    "name": "ja_rome",
+    "introduction": "平凡的脚步也可以走出伟大的行程",
+    "url": "https://me.csdn.net/jlh912008548",
+    "title": "前去学习"
+  }
+]

--- a/source/_data/recommends.json
+++ b/source/_data/recommends.json
@@ -1,0 +1,18 @@
+[
+  {
+    "title": "推荐阅读1",
+    "path": "https://github.com/blinkfox/hexo-theme-matery/blob/develop/README_CN.md",
+    "img": "https://res.cloudinary.com/liuzhihang/image/upload/v1568885685/feature/2019-09-07-nt6X1A_krvmnd.jpg",
+    "summary": "matery主题使用说明书, 读完之后, 更好的使用主题~~",
+    "categoryPath": "",
+    "categoryName": ""
+  },
+  {
+    "title": "推荐阅读2",
+    "path": "/404.html",
+    "img": "https://res.cloudinary.com/liuzhihang/image/upload/v1571114928/feature/188206_hfdfvm.jpg",
+    "summary": "在业余时间, 上下班地铁时间, 给自己充充电...",
+    "categoryPath": "/categories/分类路径/",
+    "categoryName": "分类名称(可以留空)"
+  }
+]


### PR DESCRIPTION
#### 提交内容:
 
1. 首页封面轮播图新增 useConfig
2. 推荐文章新增 useConfig

#### 解决问题:

1. 使用后博客文章可以不再配置 `top` `cover` `coverImg` 属性.
2. 防止top和其他hexo top 排序插件冲突的问题
3. 文章增多, 想更改时, 需要返回修改top, cover等问题, 同时使用配置文件可以修改排序
4. 可以在 cover和recommend使用外部链接

#### 使用方式:
1. 默认未打开, 即还是原来的使用方式, 修改useConfig需要同时增加配置文件
2. 将主题 hexo-theme-matery/source/_data/covers.json 移动到 my-blog/source/_data/下修改配置即可