### PR TITLE
解决主页切换页码按钮无法正常工作

### DIFF
--- a/layout/_partial/paging.ejs
+++ b/layout/_partial/paging.ejs
@@ -2,7 +2,7 @@
     <div class="row">
         <div class="col s6 m4 l4">
             <% if (page.prev) { %>
-            <a href="<%- url_for(page.prev_link) %>"
+            <a href="/<%- url_for(page.prev_link) %>"
                class="left btn-floating btn-large waves-effect waves-light bg-color">
                 <i class="fas fa-angle-left"></i>
             </a>
@@ -17,7 +17,7 @@
         </div>
         <div class="col s6 m4 l4">
             <% if (page.next) { %>
-            <a href="<%- url_for(page.next_link) %>"
+            <a href="/<%- url_for(page.next_link) %>"
                class="right btn-floating btn-large waves-effect waves-light bg-color">
                 <i class="fas fa-angle-right"></i>
             </a>


### PR DESCRIPTION
问题：主页切换页码按钮的时候，第一页到第二页是正常的，但是第二页不能正常返回第一页和前进到第三页
解决：在跳转链接处添加"/"