### PR TITLE
修复上次bugfix的提交未能正确处理jsdelivr为空的情形

### DIFF
--- a/layout/_partial/post-cover.ejs
+++ b/layout/_partial/post-cover.ejs
@@ -18,7 +18,7 @@ if (page.img) {
 
     var len = theme.featureImages.length;
     var num = Math.abs(hashCode(page.title) % len);
-    featureimg = theme.jsDelivr.url + theme.featureImages[num];
+    featureimg = theme.jsDelivr.url? theme.jsDelivr.url+ theme.featureImages[num]:theme.featureImages[num];
 }
 %>
 

--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -76,7 +76,7 @@
 
                                 var len = featureImages.length;
                                 var num = Math.abs(hashCode(post.title) % len);
-                                featureimg = theme.jsDelivr.url + featureImages[num];
+                                featureimg = featureImages[num];
                             %>
                             <img src="<%- theme.jsDelivr.url %><%- featureimg %>" class="responsive-img" alt="<%- post.title %>">
                             <% } %>


### PR DESCRIPTION
之前的提交没有测试jsdelivr值为null时情形，结果导致jsdelivr为空时，链接前多个null，post-detail的特征图图片无法加载。