### PR TITLE
fix google-analytics

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -74,6 +74,7 @@
     <meta name="format-detection" content="telephone=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <%- partial('_partial/google-analytics') %>
     <title><%= pageTitle %></title>
     <link rel="icon" type="<%= iconType %>" href="<%- theme.jsDelivr.url %><%- theme.favicon %>">
 

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -18,7 +18,6 @@
     <script src="<%- theme.jsDelivr.url %><%- theme.libs.js.lightgallery %>"></script>
     <script src="<%- theme.jsDelivr.url %>/js/matery.js"></script>
 
-    <%- partial('_partial/google-analytics') %>
     <%- partial('_partial/baidu-analytics') %>
     <%- partial('_partial/baidu-push') %>
     <% if (theme.clicklove.enable) { %>


### PR DESCRIPTION
> To install the global site tag, copy the following code and paste it immediately after the `<head>` tag on every page of your site. Replace `GA_MEASUREMENT_ID` with the ID of the Google Analytics property to which you want to send data. You need only one global snippet per page.

```javascript
<!-- Global site tag (gtag.js) - Google Analytics -->
<script async src="https://www.googletagmanager.com/gtag/js?id=GA_MEASUREMENT_ID"></script>
<script>
  window.dataLayer = window.dataLayer || [];
  function gtag(){dataLayer.push(arguments);}
  gtag('js', new Date());

  gtag('config', 'GA_MEASUREMENT_ID');
</script>
```

from: https://developers.google.com/analytics/devguides/collection/gtagjs

应该把 `<%- partial('_partial/google-analytics') %>` 放在 *layout/_partial/head.ejs* 才能生效，这样才能通过 Ownership Verfication