### PR TITLE
fix 部署在子目录时首页卡片背景图与推荐文章背景图路径问题

### DIFF
--- a/layout/_widget/recommend.ejs
+++ b/layout/_widget/recommend.ejs
@@ -49,7 +49,8 @@
     <% for (var i = 0; i < topPostsCount; i++) { %>
     <%
         var post = topPosts[i];
-        var featureImg = post.img ? post.img : featureImages[Math.abs(hashCode(post.title) % imgCount)];
+        var num = Math.abs(hashCode(post.title) % imgCount);
+        var featureImg = post.img ? post.img : (config.root ? config.root + featureImages[num] : featureImages[num]);
         var bgColor = bgColorArr[i % colorCount];
     %>
     <div class="col s12 m6" <% if (i > 1) { %>data-aos="zoom-in-up"<% } %>>
@@ -91,7 +92,8 @@
         if (post.summary && post.summary.length > 0) {
             description = post.summary;
         }
-        var featureImg = post.img ? post.img : featureImages[Math.abs(hashCode(post.title) % imgCount)];
+        var num = Math.abs(hashCode(post.title) % imgCount);
+        var featureImg = post.img ? post.img : (config.root ? config.root + featureImages[num] : featureImages[num]);
         var bgColor = bgColorArr[i % colorCount];
     %>
     <div class="col <%- grid %>" <% if (i > 0) { %>data-aos="zoom-in-up"<% } %>>

--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -71,7 +71,7 @@
 
                                 var len = featureImages.length;
                                 var num = Math.abs(hashCode(post.title) % len);
-                                featureimg = featureImages[num];
+                                featureimg = config.root ? config.root + featureImages[num] : featureImages[num];
                             %>
                             <img src="<%- theme.jsDelivr.url %><%- featureimg %>" class="responsive-img" alt="<%- post.title %>">
                             <% } %>


### PR DESCRIPTION
使用子目录部署时，首页文章列表卡片背景图与推荐位文章背景图路径错误，因此在模板中修改这两处图片的路径参数：当 `_config.yml` 中 `root` 参数配置时， 取 `config.root + featureImage` 为图片路径。