### PR TITLE
fix: 首页文章描述省略号遮挡不全

### DIFF
--- a/source/css/matery.css
+++ b/source/css/matery.css
@@ -1994,7 +1994,7 @@ footer .copy-right {
     /* absolute position */
     position: absolute;
     /* set position to right bottom corner of block */
-    right: 0;
+    right: 0.2em;
     bottom: 0;
 }
 
@@ -2009,7 +2009,8 @@ footer .copy-right {
     /* set width and height */
     width: 1em;
     height: 1em;
-    margin-top: 0.2em;
+    /* fix the problem of hidden failure */
+    margin-top: 0.4em;
     /* bg color = bg color under block */
     background: white;
 }


### PR DESCRIPTION
更改前
![`$ J}88DVVU AOR%69 WKDS](https://user-images.githubusercontent.com/47357585/76819700-f6be8500-6843-11ea-8c22-c8480138fc51.png)

更改后
![DPB%`XMC` OE NR7ZL@ }L9](https://user-images.githubusercontent.com/47357585/76819766-22416f80-6844-11ea-9469-238e9c05a9f5.png)
