### PR TITLE
修复手机端页面宽度溢出的问题

### DIFF
--- a/layout/_partial/gitalk.ejs
+++ b/layout/_partial/gitalk.ejs
@@ -2,7 +2,7 @@
 <link rel="stylesheet" href="<%- theme.jsDelivr.url %>/css/my-gitalk.css">
 
 <div class="card gitalk-card" data-aos="fade-up">
-    <div class="comment_headling" style="font-size: 20px; font-weight: 700; position: relative; left: 20px; top: 15px; padding-bottom: 5px;">
+    <div class="comment_headling" style="font-size: 20px; font-weight: 700; position: relative; padding-left: 20px; top: 15px; padding-bottom: 5px;">
         <i class="fas fa-comments fa-fw" aria-hidden="true"></i>
         <span>评论</span>
     </div>

--- a/layout/_partial/gitment.ejs
+++ b/layout/_partial/gitment.ejs
@@ -2,7 +2,7 @@
 <link rel="stylesheet" href="<%- theme.jsDelivr.url %>/css/gitment.css">
 
 <div class="gitment-card card" data-aos="fade-up">
-    <div class="comment_headling" style="font-size: 20px; font-weight: 700; position: relative; left: 20px; top: 15px; padding-bottom: 5px;">
+    <div class="comment_headling" style="font-size: 20px; font-weight: 700; position: relative; padding-left: 20px; top: 15px; padding-bottom: 5px;">
         <i class="fas fa-comments fa-fw" aria-hidden="true"></i>
         <span>评论</span>
     </div>

--- a/layout/_partial/valine.ejs
+++ b/layout/_partial/valine.ejs
@@ -235,7 +235,7 @@
 </style>
 
 <div class="card valine-card" data-aos="fade-up">
-    <div class="comment_headling" style="font-size: 20px; font-weight: 700; position: relative; left: 20px; top: 15px; padding-bottom: 5px;">
+    <div class="comment_headling" style="font-size: 20px; font-weight: 700; position: relative; padding-left: 20px; top: 15px; padding-bottom: 5px;">
         <i class="fas fa-comments fa-fw" aria-hidden="true"></i>
         <span>评论</span>
     </div>


### PR DESCRIPTION
之前手机端的评论card的标题会有下图的这个问题，它的样式是`left:20px`，导致页面宽度溢出手机屏幕宽度，页面可以左右滑动

![](https://api.codetool.top/img/15847156481696.png)

应该将该标题样式设置为`padding-left:20px`，修复后如下图所示

![](https://api.codetool.top/img/15847157834108.png)