### PR TITLE
修复文章版权声明中链接跳转错误

### DIFF
--- a/layout/_partial/reprint-statement.ejs
+++ b/layout/_partial/reprint-statement.ejs
@@ -12,7 +12,7 @@ let reprintPolicy = page.reprintPolicy || theme.reprint.default || 'cc_by';
                     </i>
                 </span>
                 <span class="reprint-info">
-                    <a href="<%- config.url %>" rel="external nofollow noreferrer"><%- page.author || config.author %></a>
+                    <a href="/about" rel="external nofollow noreferrer"><%- page.author || config.author %></a>
                 </span>
             </div>
             <div class="reprint__type">
@@ -22,7 +22,7 @@ let reprintPolicy = page.reprintPolicy || theme.reprint.default || 'cc_by';
                     </i>
                 </span>
                 <span class="reprint-info">
-                    <a href="<%- config.url %><%- url_for(page.path) %>"><%- config.url %><%- url_for(page.path) %></a>
+                    <a href="<%- url_for(page.path) %>"><%- config.url %><%- url_for(page.path) %></a>
                 </span>
             </div>
             <div class="reprint__notice">
@@ -35,7 +35,7 @@ let reprintPolicy = page.reprintPolicy || theme.reprint.default || 'cc_by';
                     <%= __('use') %>
                     <a href="<%= __('cc_by_url') %>" rel="external nofollow noreferrer" target="_blank"><%= __('cc_by_name') %></a>
                     <%= __('licensed') %>
-                    <a href="<%- config.url %>" target="_blank"><%- page.author || config.author %></a>
+                    <a href="/about" target="_blank"><%- page.author || config.author %></a>
                     !
                 </span>
             </div>
@@ -47,7 +47,7 @@ let reprintPolicy = page.reprintPolicy || theme.reprint.default || 'cc_by';
                     </i>
                 </span>
                 <span class="reprint-info">
-                    <a href="<%- config.url %>" rel="external nofollow noreferrer"><%- page.author || config.author %></a>
+                    <a href="about" rel="external nofollow noreferrer"><%- page.author || config.author %></a>
                 </span>
             </div>
             <div class="reprint__type">


### PR DESCRIPTION
版权声明中的链接都出现404错误。将文章的版权声明中作者链接指向了本站about页面，文章链接指向了该文章的永久链接。但这样会产生一个新问题，如果文章署名是另一作者而非博客拥有者，这个功能就形同虚设。但我看原本代码写的是config.url，是否读取的是hexo的配置文件中的url项也就是博客的域名，主题大佬应该最初也没考虑作者署名的情况吧？