### PR TITLE
首页元素不全时的`开始阅读`跳转行为和首页卡片摘要显示

### DIFF
--- a/layout/_partial/index-cover.ejs
+++ b/layout/_partial/index-cover.ejs
@@ -65,7 +65,10 @@ var coverPostsCount = coverPosts.length;
             <%- partial('_partial/bg-cover-content') %>
 
             <div class="cover-btns">
-                <a href="#indexCard" class="waves-effect waves-light btn">
+                <a href="<%=
+                        [theme.dream, theme.music, theme.video, theme.recommend]
+                                .every(i=>i.enable)? "#indexCard": "#articles"
+                        %>" class="waves-effect waves-light btn">
                     <i class="fa fa-angle-double-down"></i><%- __('startRead') %>
                 </a>
 

--- a/layout/_partial/prev-next.ejs
+++ b/layout/_partial/prev-next.ejs
@@ -43,7 +43,7 @@ var featureImages = theme.featureImages;
                         <% if (page.prev.summary && page.prev.summary.length > 0) { %>
                             <%- page.prev.summary %>
                         <% } else { %>
-                            <%- strip_html(page.prev.content).substring(0, 120) %>
+                            <%- strip_html(page.prev.excerpt).substring(0, 120) %>
                         <% } %>
                     </div>
                     <div class="publish-info">
@@ -103,7 +103,7 @@ var featureImages = theme.featureImages;
                         <% if (page.summary && page.summary.length > 0) { %>
                             <%- page.summary %>
                         <% } else { %>
-                            <%- strip_html(page.content).substring(0, 120) %>
+                            <%- strip_html(page.excerpt).substring(0, 120) %>
                         <% } %>
                     </div>
                     <div class="publish-info">
@@ -165,7 +165,7 @@ var featureImages = theme.featureImages;
                         <% if (page.next.summary && page.next.summary.length > 0) { %>
                             <%- page.next.summary %>
                         <% } else { %>
-                            <%- strip_html(page.next.content).substring(0, 120) %>
+                            <%- strip_html(page.next.excerpt).substring(0, 120) %>
                         <% } %>
                     </div>
                     <div class="publish-info">
@@ -225,7 +225,7 @@ var featureImages = theme.featureImages;
                         <% if (page.summary && page.summary.length > 0) { %>
                             <%- page.summary %>
                         <% } else { %>
-                            <%- strip_html(page.content).substring(0, 120) %>
+                            <%- strip_html(page.excerpt).substring(0, 120) %>
                         <% } %>
                     </div>
                     <div class="publish-info">

--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -81,7 +81,7 @@
                             <% if (post.summary && post.summary.length > 0) { %>
                                 <%- post.summary %>
                             <% } else { %>
-                                <%- strip_html(post.content).substring(0, 120) %>
+                                <%- strip_html(post.excerpt).substring(0, 120) %>
                             <% } %>
                         </div>
                         <div class="publish-info">


### PR DESCRIPTION
* 修复 不设置梦想、音乐、视频、推荐文章时，阅读更多按钮不跳转，更改行为为跳到文章列表。
* 修改 文章不设置summary时，显示Hexo内建的excerpt摘要，而不是content全文，它在Hexo中用`<!--more-->`断开。`hexo-theme-matery`的文章加密仅仅加密了显示，文章内容在控制台明文，当尝试使用[Hexo-blog-encrypt](https://github.com/MikeCoder/hexo-blog-encrypt)加密hexo构建结果时，因为`Hexo-blog-encrypt`加密Hexo渲染结果`content`的截断内容乱码，这个修改使`hexo-theme-matery`和`Hexo-blog-encrypt`兼容。