### PR TITLE
修复开启 jsDelivr 无法搜索问题

### DIFF
--- a/layout/_partial/search.ejs
+++ b/layout/_partial/search.ejs
@@ -13,6 +13,6 @@
 <script src="<%- theme.jsDelivr.url %><%- url_for('/js/search.js') %>"></script>
 <script type="text/javascript">
 $(function () {
-    searchFunc("<%- theme.jsDelivr.url %><%- url_for('search.xml') %>", 'searchInput', 'searchResult');
+    searchFunc('search.xml', 'searchInput', 'searchResult');
 });
 </script>


### PR DESCRIPTION
在个人服务器搭建 hexo 使用此主题，并启用 jsDelivr 时将会出现可以打开搜索框，但是输入字符之后无法进行搜索的情况。这种情况不会出现在在 Github 和 Gitee 等平台，而会在个人独立服务器上。原因是启用 jsDelivr 后，jsDelivr 并未保存有 search.xml 文件，所以无法进行搜索获得结果。如果按照原有方法，则需要每次生成 search.xml 文件都需要向 jsDelivr 上传一份，个人服务器才能实现正常搜索，但是这样做的话就比较反人类了。而且，从文件类型上来说，search.xml 属于会跟随文章变动而变动的会经常更新的文件，所以从此角度来说，此文件也不应该上传到 CDN 上。