### PR TITLE
修复开启 jsDelivr 无法搜索问题

### DIFF
--- a/layout/_partial/search.ejs
+++ b/layout/_partial/search.ejs
@@ -13,6 +13,6 @@
 <script src="<%- theme.jsDelivr.url %><%- url_for('/js/search.js') %>"></script>
 <script type="text/javascript">
 $(function () {
-    searchFunc("<%- url_for('search.xml') %>", 'searchInput', 'searchResult');
+    searchFunc('/search.xml', 'searchInput', 'searchResult');
 });
 </script>

--- a/source/js/search.js
+++ b/source/js/search.js
@@ -50,7 +50,7 @@ var searchFunc = function (path, search_id, content_id) {
                     }
                     // show search results
                     if (isMatch) {
-                        str += "<li><a href='" + data_url + "' class='search-result-title'>" + data_title + "</a>";
+                        str += "<li><a href='" + "/" + data_url + "' class='search-result-title'>" + data_title + "</a>";
                         var content = data.content.trim().replace(/<[^>]+>/g, "");
                         if (first_occur >= 0) {
                             // cut out 100 characters


### PR DESCRIPTION
修补搜索在 archives、about 等页面无法正常使用问题，主要使用了添加使用绝对路径的方法来进行解决。