### PR TITLE
修复"闪烁之狐"的"狐"字在手机端向下溢出的问题

### DIFF
--- a/source/css/matery.css
+++ b/source/css/matery.css
@@ -603,7 +603,7 @@ header .go-back i {
 
 .bg-cover .title {
     font-size: 4rem;
-    line-height: 1.85em;
+    line-height: 1.2em;
     margin-bottom: 20px;
     position: relative;
 }

--- a/source/css/matery.css
+++ b/source/css/matery.css
@@ -323,7 +323,7 @@ header .brand-logo .logo-img {
 }
 
 header .brand-logo .logo-span {
-    font-size: 2rem;
+    font-size: 1.6rem;
 }
 
 /*修改顶部 logo 的文字垂直对齐为 top，避免默认 middle 看起来偏下*/


### PR DESCRIPTION
修复 "闪烁之狐" 的 "狐" 字在手机端向下溢出的问题，同时标题title支持4个字符不会出现溢出情况。
原代码"狐"字溢出情况如图：https://s1.ax1x.com/2020/10/13/04lZ6I.png
修复后如图：https://s1.ax1x.com/2020/10/13/04lu0f.png