### PR TITLE
修复在主页上搜索后，跳转url错误的bug

### DIFF
--- a/source/js/search.js
+++ b/source/js/search.js
@@ -50,7 +50,7 @@ var searchFunc = function (path, search_id, content_id) {
                     }
                     // show search results
                     if (isMatch) {
-                        str += "<li><a href='" + "/" + data_url + "' class='search-result-title'>" + data_title + "</a>";
+                        str += "<li><a href='" + data_url + "' class='search-result-title'>" + data_title + "</a>";
                         var content = data.content.trim().replace(/<[^>]+>/g, "");
                         if (first_occur >= 0) {
                             // cut out 100 characters


### PR DESCRIPTION
去掉了多余的“\”，不然会有两个“\\”导致跳转页面url错误。