### PR TITLE
:bug: :lipstick: 修正文章拖动到底部时，页面跳动的问题

### DIFF
--- a/layout/_partial/post-detail-toc.ejs
+++ b/layout/_partial/post-detail-toc.ejs
@@ -40,7 +40,7 @@
     }
 
     #toc-content {
-        height: calc(100vh - 250px);
+        height: calc(100vh - 300px);
         overflow: auto;
     }
 


### PR DESCRIPTION
也许有更优雅的方式，能够智能地对高度进行判断？

该问题似乎是下面这个bug的后续

#571 