### PR TITLE
Fix START button

### DIFF
--- a/layout/_partial/index-cover.ejs
+++ b/layout/_partial/index-cover.ejs
@@ -67,7 +67,7 @@ var coverPostsCount = coverPosts.length;
             <div class="cover-btns">
                 <a href="<%=
                         [theme.dream, theme.music, theme.video, theme.recommend]
-                                .every(i=>i.enable)? "#indexCard": "#articles"
+                                .some(i=>i.enable)? "#indexCard": "#articles"
                         %>" class="waves-effect waves-light btn">
                     <i class="fa fa-angle-double-down"></i><%- __('startRead') %>
                 </a>


### PR DESCRIPTION
Now the START button on the front page would bring user to the #indexCard as long as there exits at least one item out of [theme.dream, theme.music, theme.video, theme.recommend]. 

.every() was changed to .some()