### PR TITLE
Closes #644: add video iframe url to provide more video source option

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -96,7 +96,8 @@ video:
   enable: false
   showTitle: true
   title: 精彩视频
-  url: # 必填
+  url: # url和iframeUrl其中一个必填
+  iframeUrl: #在bilibili或者爱奇艺分享时选择iframe，然后填那个url来这里，sample: //player.bilibili.com/player.html?aid=669520137&bvid=BV1oa4y1L7mw&cid=234543483&page=1
   pic:
   thumbnails:
   height: # 如：400

--- a/layout/_widget/video.ejs
+++ b/layout/_widget/video.ejs
@@ -6,10 +6,14 @@
     </div>
     <% } %>
     <div class="row">
+		<% if (theme.video.url) { %>
         <div class="col l8 offset-l2 m10 offset-m1 s12">
             <div id="dplayer" class="dplayer-video"
                     <% if (theme.video.height) { %> style="height: <%- theme.video.height %>px;"<% } %>></div>
         </div>
+		<% }else{ %>
+			<iframe src='<% if (theme.video.iframeUrl) { %><%- url_for(theme.video.iframeUrl) %><% } %>' scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" align="middle" <% if (theme.video.height) { %> style="height: <%- theme.video.height %>px;"<% } %> width="100%"> </iframe>
+		<% } %>
     </div>
 </div>
 

--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -21,7 +21,7 @@
                         <%- partial('_widget/music') %>
                         <% } %>
 
-                    <% if (theme.video.enable) { %>
+                    <% if (theme.video.enable && ( theme.video.url || theme.video.iframeUrl ) ) { %>
                         <%- partial('_widget/video') %>
                     <% } %>
 


### PR DESCRIPTION
if video is not own by us, host in other website(bilibili, iqiyi), mostly only can add iframe which provide by the other website's share.
sample: https://abcd_1101.gitee.io/gitee-public-blog/