### PR TITLE
添加功能：首页不显示某个文章

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,7 @@ Everything in the Front-matter option is **not required**. But I still recommend
 | author     | `author` in root `_config.yml` | Post author                                    |
 | img        | a value in `featureImages`  | Post feature image，For example: `http://xxx.com/xxx.jpg` |
 | top        | `true`                      | Recommended post (whether the post is topped), if the `top` value is `true`, it will be recommended as a homepage post. |
+| hide        | `false`                      | Whether show this post in homepage, if the `hide` value is `true`, it will not be showed in homepage. |
 | cover      | `false`                     | The `v1.0.2` version is added to indicate whether the post needs to be added to the homepage carousel cover. |
 | coverImg   | null                        | The new version of `v1.0.2` indicates that the post needs to display the image path on the cover of the homepage. If not, the default image of the post is used by default. |
 | password   | null                        | The post read the password. If you want to set the reading verification password for the article, you can set the value of `password`, which must be encrypted with `SHA256` to prevent others from seeing it. The premise is that the `verifyPassword` option is activated in the theme's `config.yml` |
@@ -527,6 +528,7 @@ date: 2018-09-07 09:25:00
 author: Qi Zhao
 img: /source/images/xxx.jpg
 top: true
+hide: false
 cover: true
 coverImg: /images/1.jpg
 password: 8d969eef6ecad3c29a3a629280e686cf0c3f5d5a86aff3ca12020c923adc6c92

--- a/README_CN.md
+++ b/README_CN.md
@@ -499,6 +499,7 @@ music:
 | author     | 根 `_config.yml` 中的 `author` | 文章作者                                                     |
 | img        | `featureImages` 中的某个值   | 文章特征图，推荐使用图床(腾讯云、七牛云、又拍云等)来做图片的路径.如: `http://xxx.com/xxx.jpg` |
 | top        | `true`                      | 推荐文章（文章是否置顶），如果 `top` 值为 `true`，则会作为首页推荐文章 |
+| hide        | `false`                    | 隐藏文章，如果`hide`值为`true`，则文章不会在首页显示 |
 | cover      | `false`                     | `v1.0.2`版本新增，表示该文章是否需要加入到首页轮播封面中 |
 | coverImg   | 无                          | `v1.0.2`版本新增，表示该文章在首页轮播封面需要显示的图片路径，如果没有，则默认使用文章的特色图片 |
 | password   | 无                          | 文章阅读密码，如果要对文章设置阅读验证密码的话，就可以设置 `password` 的值，该值必须是用 `SHA256` 加密后的密码，防止被他人识破。前提是在主题的 `config.yml` 中激活了 `verifyPassword` 选项 |
@@ -536,6 +537,7 @@ date: 2018-09-07 09:25:00
 author: 赵奇
 img: /source/images/xxx.jpg
 top: true
+hide: false
 cover: true
 coverImg: /images/1.jpg
 password: 8d969eef6ecad3c29a3a629280e686cf0c3f5d5a86aff3ca12020c923adc6c92

--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -55,7 +55,7 @@
     <article id="articles" class="container articles">
         <div class="row article-row">
             <% page.posts.forEach(post => { %>
-            <% if (post.notshow != true) <!-- 隐藏某个文章 -->
+            <% if (post.hide != true) <!-- 隐藏某个文章 -->
             <div class="article col s12 m6 l4" data-aos="zoom-in">
                 <div class="card">
                     <a href="<%- url_for(post.path) %>">

--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -55,7 +55,7 @@
     <article id="articles" class="container articles">
         <div class="row article-row">
             <% page.posts.forEach(post => { %>
-            <% if (post.hide != true) <!-- 隐藏某个文章 -->
+            <% if (post.hide != true)  { %> <!-- 隐藏某个文章 -->
             <div class="article col s12 m6 l4" data-aos="zoom-in">
                 <div class="card">
                     <a href="<%- url_for(post.path) %>">

--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -55,6 +55,7 @@
     <article id="articles" class="container articles">
         <div class="row article-row">
             <% page.posts.forEach(post => { %>
+            <% if (post.notshow != true) <!-- 隐藏某个文章 -->
             <div class="article col s12 m6 l4" data-aos="zoom-in">
                 <div class="card">
                     <a href="<%- url_for(post.path) %>">
@@ -120,6 +121,7 @@
                     <% } %>
                 </div>
             </div>
+            <% } %>  <!-- 隐藏某个文章 -->
             <% }); %>
         </div>
     </article>


### PR DESCRIPTION
## 加入该功能的目的
Motivation: 比如在博客上写日记，但又不想在首页被人看到，就可以利用这个功能。又比如有的人在博客上写文档，也不希望在主页显示。

我在[issue](https://github.com/blinkfox/hexo-theme-matery/issues/597)中也看到了有人提到希望加入这么一个功能，我也正好有这种需求，
## 功能描述
首页不显示某个文章，但是在分类、归档中可见。

## 实现方式
在index.ejs中加入了2行代码：
```
<% if (post.hide != true) { %>
. . .
<% }); %>
```
（我的js水平只限于能看懂，可能实现的不对。。）
## 其他
README中英文我也做了对应的修改
