### PR TITLE
fix bugs of copying code when copyright enabled

### DIFF
--- a/layout/_partial/post-detail.ejs
+++ b/layout/_partial/post-detail.ejs
@@ -219,7 +219,7 @@
 
         // we need a <pre> tag workaround.
         // otherwise the text inside "pre" loses all the line breaks!
-        if (selection.getRangeAt(0).commonAncestorContainer.nodeName === 'PRE') {
+        if (selection.getRangeAt(0).commonAncestorContainer.nodeName === 'PRE' || selection.getRangeAt(0).commonAncestorContainer.nodeName === 'CODE') {
             newdiv.innerHTML = "<pre>" + newdiv.innerHTML + "</pre>";
         }
 


### PR DESCRIPTION
if `copyright.enabled == true`, copying block code will lose all the line breaks. This change fixes it.