### PR TITLE
MathJax和英文小括号的冲突解决

### DIFF
--- a/layout/post.ejs
+++ b/layout/post.ejs
@@ -34,7 +34,7 @@
 <script src="<%- theme.mathjax.cdn %>"></script>
 <script>
     MathJax.Hub.Config({
-        tex2jax: {inlineMath: [['$', '$'], ['\(', '\)']]}
+        tex2jax: {inlineMath: [['$', '$'], ['\\(', '\\)']]}
     });
 </script>
 <% } %>


### PR DESCRIPTION
解决开启MathJax后在博客markdown不能正确显示小括号内容的问题
另外MathJax，版本升级到3要不要提交？